### PR TITLE
refactor: Migrate action build script calls to submodule

### DIFF
--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -36,9 +36,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
       - name: Dynamically generate resources.md file
-        run: ./scripts/generate_resources.sh
+        run: ./mdbook-resources/scripts/generate-resources
 
       - name: Cache mdbook binary
         id: cache-mdbook
@@ -50,7 +52,7 @@ jobs:
 
       - name: Fetch mdBook binary from mdBook repository if not cached
         if: steps.cache-mdbook.outputs.cache-hit != 'true'
-        run: bash ./scripts/binary-validation.sh ${MDBOOK_VERSION}
+        run: ./mdbook-resources/scripts/binary-validation ${MDBOOK_VERSION}
 
       - name: Setup Pages
         id: pages


### PR DESCRIPTION
Crosses `scripts/` off the list in #11 


In order for the submodule to be populated in the checkout action, we needed to add `submodules: recurse` as an argument.